### PR TITLE
Updated oath2 dependency 

### DIFF
--- a/salesforce_bulk_api.gemspec
+++ b/salesforce_bulk_api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{Salesforce Bulk API with governor limits taken care of}
 
   s.rubyforge_project = "salesforce_bulk_api"
-  s.add_dependency(%q<oauth2>, ["0.4.1"])
+  s.add_dependency(%q<oauth2>, ["~> 0.9.1"])
   s.add_dependency(%q<databasedotcom>, [">= 0"])
   s.add_dependency(%q<json>, [">= 0"])
   s.add_dependency(%q<xml-simple>, [">= 0"])


### PR DESCRIPTION
Updated the oauth2 dependance to be ~> 0.9.1. The reason for the change is people who use SalesForce's bulk API might also use the restforce gem which is used for SalesForce's streaming API. Restforce gem requires faraday ~> 0.8.4 where the current version of oauth2 4.1 uses faraday ~> 0.6.1.  

I have tested oauth2 0.9.1 with my app and can still authentication and use the bulk API without issue. 
