### PR TITLE
removed oauth dependency

### DIFF
--- a/salesforce_bulk_api.gemspec
+++ b/salesforce_bulk_api.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Salesforce Bulk API with governor limits taken care of}
 
   s.rubyforge_project = "salesforce_bulk_api"
-  s.add_dependency(%q<oauth2>, [">= 0.9.1"])
   s.add_dependency(%q<databasedotcom>, [">= 0"])
   s.add_dependency(%q<json>, [">= 0"])
   s.add_dependency(%q<xml-simple>, [">= 0"])


### PR DESCRIPTION
oauth is not used inside this gem (auth is handled by databasedotcom gem), and the dependency created problems with devise and google-oauth versions I was using.
