### PR TITLE
oauth2 support added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in salesforce_bulk_api.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ or add
    
 in your Gemfile
 
-There are two ways to authenticate with SalesForce to use the Bulk API: databasedotcom & restforce.
-Please check out the entire documentation of the gem you decide to use to learn the various ways of authentication.
+There are three ways to authenticate with SalesForce to use the Bulk API. The first two leverage 
+existing SalesForce API gems: [Databasedotcom](https://github.com/heroku/databasedotcom) & [Restforce](https://github.com/ejholmes/restforce). Please check out the entire documentation 
+of the gem you decide to use to learn the various ways of authentication.
 
-[Databasedotcom](https://github.com/heroku/databasedotcom)
-[Restforce](https://github.com/ejholmes/restforce)
+If you don’t want to install the aforementioned gems, the Salesforce-Bulk-Api will default to oauth2 for 
+authentication. This requires passing a hash of SalesForce authentication attributes. 
+See below for examples. 
 
-
-You can use username password combo, OmniAuth, Oauth2
 You can use as many records possible in the Array. Governor limits are taken care of inside the gem.
 
+DATABASEDOTCOM GEM
 
 	require 'salesforce_bulk_api'
 	client = Databasedotcom::Client.new :client_id =>  SFDC_APP_CONFIG["client_id"], :client_secret => SFDC_APP_CONFIG["client_secret"] #client_id and client_secret respectively
@@ -35,7 +36,7 @@ You can use as many records possible in the Array. Governor limits are taken car
 
     salesforce = SalesforceBulkApi::Api.new(client)
 
-OR
+RESTFORCE GEM
 
 	require 'salesforce_bulk_api'
 	client = Restforce.new(
@@ -49,6 +50,16 @@ OR
 
 	salesforce = SalesforceBulkApi::Api.new(client)
 
+OAUTH2
+
+	require 'salesforce_bulk_api'
+	salesforce = SalesforceBulkApi::Api.new({
+	 :client_id=>"client_id",
+	 :client_secret=>"client_secret",
+	 :host=>"host_name",
+	 :username=>"username",
+	 :password=>"password + security_token"
+	})
 
 Sample operations:
 

--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -43,8 +43,6 @@ module SalesforceBulkApi
       self.do_operation('query', sobject, query, nil, true, timeout, batch_size)
     end
 
-    #private
-
     def do_operation(operation, sobject, records, external_field, get_response, timeout, batch_size, send_nulls = false, no_null_list = [])
       job = SalesforceBulkApi::Job.new(operation, sobject, records, external_field, @connection)
 

--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -7,6 +7,7 @@ require 'xmlsimple'
 require 'csv'
 require 'salesforce_bulk_api/job'
 require 'salesforce_bulk_api/connection'
+require 'salesforce_bulk_api/authentication'
 
 module SalesforceBulkApi
   
@@ -15,6 +16,10 @@ module SalesforceBulkApi
     @@SALESFORCE_API_VERSION = '23.0'
 
     def initialize(client)
+      if client.is_a?(Hash)
+        client = SalesforceBulkApi::Authentication.new(client)
+        client = client.get_token
+      end
       @connection = SalesforceBulkApi::Connection.new(@@SALESFORCE_API_VERSION,client)
     end
 

--- a/lib/salesforce_bulk_api/authentication.rb
+++ b/lib/salesforce_bulk_api/authentication.rb
@@ -1,0 +1,38 @@
+require 'oauth2'
+require 'socket'
+
+module SalesforceBulkApi
+	attr_accessor :oauth_client
+	attr_accessor :options
+  
+  class Authentication
+
+  	def initialize(options = {})
+  	  @options = options
+  	  @options.symbolize_keys!
+	  end
+
+	  def get_token
+			@oauth_client = OAuth2::Client.new(
+				@options[:client_id],
+				@options[:client_secret],
+				:site => "https://#{@options[:host]}",
+				:authorize_url => '/services/oauth2/authorize',
+				:token_url => '/services/oauth2/token'
+			)
+			@oauth_client.password.get_token(@options[:username], @options[:password])
+	  end
+
+	  private
+
+	  def host_name
+	  	host_name = ENV['ORIGIN']
+	  	if host_name.nil? || host_name.strip.empty?
+	  		get_host_name = Socket.gethostname
+	  	  host_name = URI.parse(get_host_name.gsub(/\?.*$/,''))     
+	  	  host_name = host_name.to_s
+	  	end
+	  	return host_name
+	  end
+	end
+end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -26,11 +26,14 @@ require 'timeout'
       client_type = @client.class.to_s
       case client_type
       when "Restforce::Data::Client"
-        @session_id=@client.options[:oauth_token]
-        @server_url=@client.options[:instance_url]
+        @session_id = @client.options[:oauth_token]
+        @server_url = @client.options[:instance_url]
+      when "OAuth2::AccessToken"
+        @session_id = @client.token
+        @server_url = @client.params["instance_url"]
       else
-        @session_id=@client.oauth_token
-        @server_url=@client.instance_url
+        @session_id = @client.oauth_token
+        @server_url = @client.instance_url
       end
       @instance = parse_instance()
       @@INSTANCE_HOST = "#{@instance}.salesforce.com"
@@ -74,7 +77,7 @@ require 'timeout'
     end
 
     def parse_instance()
-      @instance=@server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
+      @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
       @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.blank?
       return @instance
     end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -9,10 +9,9 @@ require 'timeout'
     @@INSTANCE_HOST = nil # Gets set in login()
 
     def initialize(api_version,client)
-      @client=client
+      @client = client
       @session_id = nil
       @server_url = nil
-      @instance = nil
       @@API_VERSION = api_version
       @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
       @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
@@ -35,8 +34,8 @@ require 'timeout'
         @session_id = @client.oauth_token
         @server_url = @client.instance_url
       end
-      @instance = parse_instance()
-      @@INSTANCE_HOST = "#{@instance}.salesforce.com"
+      instance = parse_instance()
+      @@INSTANCE_HOST = "#{instance}.salesforce.com"
     end
 
     def post_xml(host, path, xml, headers)
@@ -77,11 +76,10 @@ require 'timeout'
     end
 
     def parse_instance()
-      @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
-      @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.blank?
-      return @instance
+      instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
+      instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.blank?
+      return instance
     end
 
   end
-
 end

--- a/lib/salesforce_bulk_api/version.rb
+++ b/lib/salesforce_bulk_api/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulkApi
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end

--- a/salesforce_bulk_api.gemspec
+++ b/salesforce_bulk_api.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<json>, [">= 0"])
   s.add_dependency(%q<xml-simple>, [">= 0"])
+  s.add_dependency(%q<oauth2>, ["~> 0.9.2"])
   
   s.add_development_dependency "rspec"
   s.add_development_dependency("webmock", ["~> 1.13"])


### PR DESCRIPTION
Added the ability for a user to submit a hash of SalesForce authentication attributes rather than being forced to rely on databasedotcom or restforce for authentication.  I have tested locally, but please test before pushing to master.