### PR TITLE
Adding databasedotcom as a development dependency.

### DIFF
--- a/salesforce_bulk_api.gemspec
+++ b/salesforce_bulk_api.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency("webmock", ["~> 1.13"])
   s.add_development_dependency("vcr", ['~> 2.5'])
+  s.add_development_dependency "databasedotcom"
   
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Rspec tests would error out before their execution unless `databasedotcom` was installed.

This changeset specifies that `databasedotcom` should be downloaded through `bundler` in a development setting.
