### PR TITLE
Removing sleep statment in lib/salesforce_bulk_api/job.rb

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -149,7 +149,6 @@ module SalesforceBulkApi
                   state << (batch_state)
                   @batch_ids.delete(batch_id)
                 end
-                sleep(3) # wait x seconds and check again
               end
               break if @batch_ids.empty?
             else


### PR DESCRIPTION
As [requested](https://github.com/yatish27/salesforce_bulk_api/issues/23#issuecomment-32122722), here is a dedicated PR for removing the sleep statement in `lib/stalesforce_bulk_api/job.rb`.

I used my branch to test functionality from within an organization I have access to, and the changeset appeared to reflect the desired changes :)

But after attempting to run tests within the `salesforce_bulk_api` project with my sandbox credentials, I encountered a few test failures.  namely because my schema was mismatched with what was expected inside of the RSpec tests.  Because I do not have access to change the schema of my organization sandbox, I don't think I can get much further running the tests in the state they are currently in.

Before accepting, I would recommend running the tests again with your credentials and against your sandbox, as it seems there is a set schema these tests are intended to run against.

Thanks!
