### PR TITLE
bump api version to 32.0

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -12,7 +12,7 @@ module SalesforceBulkApi
 
   class Api
 
-    @@SALESFORCE_API_VERSION = '23.0'
+    @@SALESFORCE_API_VERSION = '32.0'
 
     def initialize(client)
       @connection = SalesforceBulkApi::Connection.new(@@SALESFORCE_API_VERSION,client)


### PR DESCRIPTION
some api features depend on this, e.g. certain fields can not be
queried in earlier api versions