### PR TITLE
Introduce counters for each SF API call

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -82,7 +82,7 @@ module SalesforceBulkApi
 
     def count(name)
       @counters ||= Hash.new(0)
-      @counters[name]
+      @counters[name] += 1
     end
 
   end

--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -39,6 +39,19 @@ module SalesforceBulkApi
       do_operation('query', sobject, query, nil, true, timeout, batch_size)
     end
 
+    def counters
+      {
+        http_get: @connection.counters[:get],
+        http_post: @connection.counters[:post],
+        upsert: @counters[:upsert],
+        update: @counters[:update],
+        create: @counters[:create],
+        delete: @counters[:delete],
+        query: @counters[:query]
+      }
+    end
+
+
     ##
     # Allows you to attach a listener that accepts the created job (which has a useful #job_id field).  This is useful
     # for recording a job ID persistently before you begin batch work (i.e. start modifying the salesforce database),
@@ -52,9 +65,9 @@ module SalesforceBulkApi
       SalesforceBulkApi::Job.new(job_id: job_id, connection: @connection)
     end
 
-    #private
-
     def do_operation(operation, sobject, records, external_field, get_response, timeout, batch_size, send_nulls = false, no_null_list = [])
+      count operation.to_sym
+
       job = SalesforceBulkApi::Job.new(operation: operation, sobject: sobject, records: records, external_field: external_field, connection: @connection)
 
       job.create_job(batch_size, send_nulls, no_null_list)
@@ -64,5 +77,13 @@ module SalesforceBulkApi
       response.merge!({'batches' => job.get_job_result(get_response, timeout)}) if get_response == true
       response
     end
+
+    private
+
+    def count(name)
+      @counters ||= Hash.new(0)
+      @counters[name]
+    end
+
   end
 end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -20,8 +20,6 @@ require 'timeout'
       login()
     end
 
-    #private
-
     def login()
       client_type = @client.class.to_s
       case client_type
@@ -37,6 +35,7 @@ require 'timeout'
     end
 
     def post_xml(host, path, xml, headers)
+      count :post
       host = host || @@INSTANCE_HOST
       if host != @@LOGIN_HOST # Not login, need to add session id to header
         headers['X-SFDC-Session'] = @session_id;
@@ -58,6 +57,7 @@ require 'timeout'
     end
 
     def get_request(host, path, headers)
+      count :get
       host = host || @@INSTANCE_HOST
       path = "#{@@PATH_PREFIX}#{path}"
       if host != @@LOGIN_HOST # Not login, need to add session id to header
@@ -77,6 +77,20 @@ require 'timeout'
       @instance=@server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
       @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.nil? || @instance.empty?
       return @instance
+    end
+
+    def counters
+      {
+        get: @connection.counters[:get],
+        post: @connection.counters[:post]
+      }
+    end
+
+    private
+
+    def count(name)
+      @counters ||= Hash.new(0)
+      @counters[name]
     end
 
   end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -81,8 +81,8 @@ require 'timeout'
 
     def counters
       {
-        get: @connection.counters[:get],
-        post: @connection.counters[:post]
+        get: @counters[:get],
+        post: @counters[:post]
       }
     end
 
@@ -90,7 +90,7 @@ require 'timeout'
 
     def count(name)
       @counters ||= Hash.new(0)
-      @counters[name]
+      @counters[name] += 1
     end
 
   end

--- a/spec/salesforce_bulk_api/salesforce_bulk_api_spec.rb
+++ b/spec/salesforce_bulk_api/salesforce_bulk_api_spec.rb
@@ -168,4 +168,26 @@ describe SalesforceBulkApi do
 
   end
 
+  describe 'counters' do
+    context 'when read operations are called' do
+      it 'increments operation count and http GET count' do
+        @api.counters[:http_get].should eq 0
+        @api.counters[:query].should eq 0
+        @api.query('Account', "SELECT Website, Phone From Account WHERE Id = '#{@account_id}'")
+        @api.counters[:http_get].should eq 1
+        @api.counters[:query].should eq 1
+      end
+    end
+
+    context 'when update operations are called' do
+      it 'increments operation count and http POST count' do
+        @api.counters[:http_post].should eq 0
+        @api.counters[:update].should eq 0
+        @api.update('Account', [{:Id => @account_id, :Website => 'abc123', :Phone => '5678'}], true)
+        @api.counters[:http_post].should eq 1
+        @api.counters[:update].should eq 1
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Salesforce API calls are subject to a quota.  Introduce counters on instances of SalesforceBulkApi::Api which count each call to the API.