### PR TITLE
Fix failure when counters not initialized

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -45,11 +45,11 @@ module SalesforceBulkApi
       {
         http_get: @connection.counters[:get],
         http_post: @connection.counters[:post],
-        upsert: @counters[:upsert],
-        update: @counters[:update],
-        create: @counters[:create],
-        delete: @counters[:delete],
-        query: @counters[:query]
+        upsert: get_counters[:upsert],
+        update: get_counters[:update],
+        create: get_counters[:create],
+        delete: get_counters[:delete],
+        query: get_counters[:query]
       }
     end
 
@@ -81,10 +81,12 @@ module SalesforceBulkApi
     end
 
     private
+    def get_counters
+      @counters ||= Hash.new(0)
+    end
 
     def count(name)
-      @counters ||= Hash.new(0)
-      @counters[name] += 1
+      get_counters[name] += 1
     end
 
   end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -84,14 +84,20 @@ require 'timeout'
     end
 
     def counters
-      @counters.dup
+      {
+        get: get_counters[:get],
+        post: get_counters[:post]
+      }
     end
 
     private
 
-    def count(http_method)
+    def get_counters
       @counters ||= Hash.new(0)
-      @counters[http_method] += 1
+    end
+
+    def count(http_method)
+      get_counters[http_method] += 1
     end
 
   end


### PR DESCRIPTION
Fixed problem with trying to retrieve from nil @counter when no requests have been made yet