### PR TITLE
Fix bug that causes throttling to never actually work by default :(

### DIFF
--- a/lib/salesforce_bulk_api/concerns/throttling.rb
+++ b/lib/salesforce_bulk_api/concerns/throttling.rb
@@ -11,7 +11,7 @@ module SalesforceBulkApi::Concerns
     end
 
     def set_status_throttle(limit_seconds)
-      set_throttle_limit_in_seconds(limit_seconds, [:http_method, :path], ->(details) { details[:path] == :get })
+      set_throttle_limit_in_seconds(limit_seconds, [:http_method, :path], ->(details) { details[:http_method] == :get })
     end
 
     def set_throttle_limit_in_seconds(limit_seconds, throttle_by_keys, only_if)


### PR DESCRIPTION
Wish I had some time to write some tests for this (complex) feature.  In any case, I discovered that my throttling was not actually working the hard way, so here's a quick fix.