### PR TITLE
Options hash, api_version, and updated test / readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ OR
 	  security_token: SFDC_APP_CONFIG['SFDC_SECURITY_TOKEN'],
 	  client_id:      SFDC_APP_CONFIG['SFDC_CLIENT_ID'],
 	  client_secret:  SFDC_APP_CONFIG['SFDC_CLIENT_SECRET'].to_i,
-	  host:           SFDC_APP_CONFIG['SFDC_HOST']
+	  host:           SFDC_APP_CONFIG['SFDC_HOST'],
+	  api_version:	  SFDC_APP_CONFIG['API_VERSION']
 	)
 
 	salesforce = SalesforceBulkApi::Api.new(client)
@@ -52,39 +53,61 @@ OR
 
 ### Sample operations:
 
-    # Insert/Create
-    # Add as many fields per record as needed.
+All operations take an optional hash as their last parameter that sets bulk API job info. The available options are
+
+|Option|Default Param|
+|------|-------------|
+|:concurrency|Parallel|
+|:get\_response|false (true for queries)|
+|:timeout|1500|
+|:batch\_size|10000 (often needs to be tuned)|
+|:send\_nulls|false|
+|:no\_null\_list|[]|
+
+# Insert/Create
+
+Add as many fields per record as needed.
+
 	new_account = Hash["name" => "Test Account", "type" => "Other"] 
 	records_to_insert = Array.new
-	# You can add as many records as you want here, just keep in mind that Salesforce has governor limits.
 	records_to_insert.push(new_account) 
-	result = salesforce.create("Account", records_to_insert)
+
+You can add as many records as you want here, just keep in mind that Salesforce has governor limits.
+
+	options = {:concurrency => 'Serial'}
+	result = salesforce.create("Account", records_to_insert, options)
 	puts "result is: #{result.inspect}"
 
-    # Update
+# Update
+
 	updated_account = Hash["name" => "Test Account -- Updated", id => "a00A0001009zA2m"] # Nearly identical to an insert, but we need to pass the salesforce id.
 	records_to_update = Array.new
 	records_to_update.push(updated_account)
 	salesforce.update("Account", records_to_update)
 
-    # Upsert
+# Upsert
+
 	upserted_account = Hash["name" => "Test Account -- Upserted", "External_Field_Name" => "123456"] # Fields to be updated. External field must be included
 	records_to_upsert = Array.new
 	records_to_upsert.push(upserted_account)
-	salesforce.upsert("Account", records_to_upsert, "External_Field_Name") # Note that upsert accepts an extra parameter for the external field name
+	options = {:batch_size => 500}
+	salesforce.upsert("Account", records_to_upsert, "External_Field_Name", options) # Note that upsert accepts an extra parameter for the external field name
 
-    # Delete
+# Delete
+
 	deleted_account = Hash["id" => "a00A0001009zA2m"] # We only specify the id of the records to delete
 	records_to_delete = Array.new
 	records_to_delete.push(deleted_account)
 	salesforce.delete("Account", records_to_delete)
 
-    # Query
+# Query
+
 	res = salesforce.query("Account", "select id, name, createddate from Account limit 3") # We just need to pass the sobject name and the query string
 
 ### Helpful methods:
 
-    # Check status of a job via #job_from_id
+# Check status of a job via #job_from_id
+
 	job = salesforce.job_from_id('a00A0001009zA2m') # Returns a SalesforceBulkApi::Job instance
 	puts "status is: #{job.check_job_status.inspect}"
 
@@ -99,8 +122,8 @@ OR
 
 ### Throttling API calls:
 
-    # By default, this gem (and maybe your app driving it) will query job/batch statuses at an unbounded rate.  We
-    # can fix that, e.g.:
+By default, this gem (and maybe your app driving it) will query job/batch statuses at an unbounded rate.  We can fix that, e.g.:
+
     salesforce.connection.set_status_throttle(30) # only check status of individual jobs/batches every 30 seconds
 
 ## Installation

--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -14,10 +14,8 @@ module SalesforceBulkApi
   class Api
     attr_reader :connection
 
-    @@SALESFORCE_API_VERSION = '32.0'
-
     def initialize(client)
-      @connection = SalesforceBulkApi::Connection.new(@@SALESFORCE_API_VERSION, client)
+      @connection = SalesforceBulkApi::Connection.new(client)
       @listeners = { job_created: [] }
     end
 

--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -19,24 +19,24 @@ module SalesforceBulkApi
       @listeners = { job_created: [] }
     end
 
-    def upsert(sobject, records, external_field, get_response = false, send_nulls = false, no_null_list = [], batch_size = 10000, timeout = 1500)
-      do_operation('upsert', sobject, records, external_field, get_response, timeout, batch_size, send_nulls, no_null_list)
+    def upsert(sobject, records, external_field, options={})
+      do_operation('upsert', sobject, records, external_field, options) 
     end
 
-    def update(sobject, records, get_response = false, send_nulls = false, no_null_list = [], batch_size = 10000, timeout = 1500)
-      do_operation('update', sobject, records, nil, get_response, timeout, batch_size, send_nulls, no_null_list)
+    def update(sobject, records, options={}) 
+      do_operation('update', sobject, records, nil, options) 
     end
 
-    def create(sobject, records, get_response = false, send_nulls = false, batch_size = 10000, timeout = 1500)
-      do_operation('insert', sobject, records, nil, get_response, timeout, batch_size, send_nulls)
+    def create(sobject, records, options={}) 
+      do_operation('insert', sobject, records, nil, options) 
     end
 
-    def delete(sobject, records, get_response = false, batch_size = 10000, timeout = 1500)
-      do_operation('delete', sobject, records, nil, get_response, timeout, batch_size)
+    def delete(sobject, records, options={}) 
+      do_operation('delete', sobject, records, nil, options) 
     end
 
-    def query(sobject, query, batch_size = 10000, timeout = 1500)
-      do_operation('query', sobject, query, nil, true, timeout, batch_size)
+    def query(sobject, query, options={}) 
+      do_operation('query', sobject, query, nil, {get_response: true}.merge(options))
     end
 
     def counters
@@ -65,16 +65,16 @@ module SalesforceBulkApi
       SalesforceBulkApi::Job.new(job_id: job_id, connection: @connection)
     end
 
-    def do_operation(operation, sobject, records, external_field, get_response, timeout, batch_size, send_nulls = false, no_null_list = [])
+    def do_operation(operation, sobject, records, external_field, options)
       count operation.to_sym
 
-      job = SalesforceBulkApi::Job.new(operation: operation, sobject: sobject, records: records, external_field: external_field, connection: @connection)
+      job = SalesforceBulkApi::Job.new(operation: operation, sobject: sobject, records: records, external_field: external_field, connection: @connection,options: options)
 
-      job.create_job(batch_size, send_nulls, no_null_list)
+      job.create_job
       @listeners[:job_created].each {|callback| callback.call(job)}
       operation == "query" ? job.add_query() : job.add_batches()
       response = job.close_job
-      response.merge!({'batches' => job.get_job_result(get_response, timeout)}) if get_response == true
+      response.merge!({'batches' => job.get_job_result}) if job.get_response
       response
     end
 

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -9,16 +9,28 @@ require 'timeout'
     @@LOGIN_HOST = 'login.salesforce.com'
     @@INSTANCE_HOST = nil # Gets set in login()
 
-    def initialize(api_version,client)
+    def initialize(client)
       @client=client
       @session_id = nil
       @server_url = nil
       @instance = nil
-      @@API_VERSION = api_version
+      @@API_VERSION = determine_api_from_client(client) 
       @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
       @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
 
       login()
+    end
+
+    def determine_api_from_client(client)
+      client_type = @client.class.to_s
+      case client_type
+      when "Restforce::Data::Client"
+        return client.options.fetch(:api_version,"32.0") # returns 32.0 if no api_version
+      when "Databasedotcom::Client"
+        return client.version
+      else
+        raise TypeError, "Client must be a restforce or databasedotcom client."
+      end
     end
 
     def login()

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -3,9 +3,9 @@ require 'timeout'
 
   class Connection
     include Concerns::Throttling
+    attr_reader :api_version
 
     @@XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'
-    @@API_VERSION = nil
     @@LOGIN_HOST = 'login.salesforce.com'
     @@INSTANCE_HOST = nil # Gets set in login()
 
@@ -14,9 +14,9 @@ require 'timeout'
       @session_id = nil
       @server_url = nil
       @instance = nil
-      @@API_VERSION = determine_api_from_client(client) 
-      @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
-      @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
+      @api_version = determine_api_from_client(client) 
+      @@LOGIN_PATH = "/services/Soap/u/#{@api_version}"
+      @@PATH_PREFIX = "/services/async/#{@api_version}/"
 
       login()
     end

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -12,6 +12,7 @@ module SalesforceBulkApi
       @external_field = args[:external_field]
       @records        = args[:records]
       @connection     = args[:connection]
+      @concurrency    = args.fetch(:concurrency,'Parallel')
       @batch_ids      = []
       @XML_HEADER     = '<?xml version="1.0" encoding="utf-8" ?>'
     end
@@ -29,6 +30,7 @@ module SalesforceBulkApi
       if !@external_field.nil? # This only happens on upsert
         xml += "<externalIdFieldName>#{@external_field}</externalIdFieldName>"
       end
+      xml += "<concurrencyMode>{@concurrency}</concurrencyMode>"
       xml += "<contentType>XML</contentType>"
       xml += "</jobInfo>"
 

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -1,7 +1,7 @@
 module SalesforceBulkApi
 
   class Job
-    attr_reader :job_id
+    attr_reader :job_id,:get_response
 
     class SalesforceException < StandardError; end
 
@@ -12,25 +12,26 @@ module SalesforceBulkApi
       @external_field = args[:external_field]
       @records        = args[:records]
       @connection     = args[:connection]
-      @concurrency    = args.fetch(:concurrency,'Parallel')
+      @concurrency    = args[:options].fetch(:concurrency,'Parallel')
+      @get_response   = args[:options].fetch(:get_response,false)
+      @timeout        = args[:options].fetch(:timeout,1500)
+      @batch_size     = args[:options].fetch(:batch_size,10000)
+      @send_nulls     = args[:options].fetch(:send_nulls,false)
+      @no_null_list   = args[:options].fetch(:no_null_list,[])
       @batch_ids      = []
       @XML_HEADER     = '<?xml version="1.0" encoding="utf-8" ?>'
     end
 
 
 
-    def create_job(batch_size, send_nulls, no_null_list)
-      @batch_size = batch_size
-      @send_nulls = send_nulls
-      @no_null_list = no_null_list
-
+    def create_job()
       xml = "#{@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
       xml += "<operation>#{@operation}</operation>"
       xml += "<object>#{@sobject}</object>"
       if !@external_field.nil? # This only happens on upsert
         xml += "<externalIdFieldName>#{@external_field}</externalIdFieldName>"
       end
-      xml += "<concurrencyMode>{@concurrency}</concurrencyMode>"
+      xml += "<concurrencyMode>#{@concurrency}</concurrencyMode>"
       xml += "<contentType>XML</contentType>"
       xml += "</jobInfo>"
 
@@ -167,11 +168,11 @@ module SalesforceBulkApi
       end
     end
 
-    def get_job_result(return_result, timeout)
+    def get_job_result()
       # timeout is in seconds
       begin
         state = []
-        Timeout::timeout(timeout, SalesforceBulkApi::JobTimeout) do
+        Timeout::timeout(@timeout, SalesforceBulkApi::JobTimeout) do
           while true
             if self.check_job_status['state'][0] == 'Closed'
               @batch_ids.each do |batch_id|
@@ -194,7 +195,7 @@ module SalesforceBulkApi
       end
 
       state.each_with_index do |batch_state, i|
-        if batch_state['state'][0] == 'Completed' && return_result == true
+        if batch_state['state'][0] == 'Completed' && @get_response
           state[i].merge!({'response' => self.get_batch_result(batch_state['id'][0])})
         end
       end


### PR DESCRIPTION
I've made a change to the API to take an optional hash to the update/upsert/insert/delete/query methods as the last parameter that allows the users of the gem to set their own options, as opposed to them being hidden / unnamed inside the method signatures.

Instead of having to do this to set the timeout:

    create('Account', records, false, false, [], 10000, 100) 

You would pass an options hash:

    create('Account',records,{:timeout => 100})

All other parameters are set with the current default settings based on the method (e.g. query has :get_response => true by default), and there is a new parameter called `:concurrency` which allows the user to set their processing method (parallel or concurrent). 

An additional change is to rely on the client for the api_version, instead of setting a constant on initialize. This allows the user to set their own api_version based on their own needs.

Finally, I've updated the readme and tests to reflect these changes, along with fixing a few tests that no longer worked after some previous commits.