### PR TITLE
update Restforce docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ OR
 	  client_secret:  SFDC_APP_CONFIG['SFDC_CLIENT_SECRET'].to_i,
 	  host:           SFDC_APP_CONFIG['SFDC_HOST']
 	)
-
+	client.authenticate!
 	salesforce = SalesforceBulkApi::Api.new(client)
 
 


### PR DESCRIPTION
Hey @yatish27!

Just a heads up that without this line, we get:

```
[10] pry(main)> salesforce = SalesforceBulkApi::Api.new(client)
NoMethodError: undefined method `match' for nil:NilClass
Did you mean?  catch
from /Users/nick/.gem/jruby/2.3.1/gems/salesforce_bulk_api-0.0.12/lib/salesforce_bulk_api/connection.rb:81:in `parse_instance'
```

when trying to do a username / password authentication using `Restforce`. Once I called `client.authenticate!`, everything worked as expected.

Thanks for your time!

cc @vadim-smolyakov