### PR TITLE
Custom Domain Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ You can use as many records possible in the Array. Governor limits are taken car
 
 OR
 
+Username Password Combo:
+
 	require 'salesforce_bulk_api'
 	client = Restforce.new(
 	  username:       SFDC_APP_CONFIG['SFDC_USERNAME'],
@@ -49,6 +51,20 @@ OR
 	client.authenticate!
 	salesforce = SalesforceBulkApi::Api.new(client)
 
+OAuth2 Combo:
+
+	require 'salesforce_bulk_api'
+	client = Restforce.new(
+	  security_token: SFDC_APP_CONFIG['SFDC_SECURITY_TOKEN'],
+	  refresh_token:  SFDC_APP_CONFIG['SFDC_REFRESH_TOKEN'],
+	  client_id:      SFDC_APP_CONFIG['SFDC_CLIENT_ID'],
+	  client_secret:  SFDC_APP_CONFIG['SFDC_CLIENT_SECRET'].to_i,
+	  host:           SFDC_APP_CONFIG['SFDC_HOST']
+	)
+	client.authenticate!
+	salesforce = SalesforceBulkApi::Api.new(client)
+
+Note: The authenticate! method of Restforce requires the presence of username, password, client id and client secret in case of username-password mode of authentication and refresh token, client id and client secret if you are going the OAuth way for authenticating with Restforce. If those options are not set, you will receive 'No authentication middleware present' error.
 
 ### Sample operations:
 

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -71,8 +71,15 @@ require 'timeout'
     end
 
     def parse_instance()
-      @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}/).to_s.gsub("https://","")
+
+    #Edited by AD to include scenarios where the domain name is something like 'ab12cdef' and the salesforce instance url is 'ab12cdef.my.salesforce.com'.
+    #In that case, as per the original case, the @instance variable will evaluate to 'ab12.salesforce.com' instead of 'ab12cdef.my.salesforce.com'.
+    #That would lead to this error --> "Failed to open TCP connection to ab12.salesforce.com:443 (getaddrinfo: Name or service not known)".
+    #In the following lines of code, we are checking to see if there is a '.' following the earlier regex to ensure that its not some fancy custom domain name.
+
+      @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}\./).to_s.gsub("https://","").split(".")[0]
       @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.nil? || @instance.empty?
+    
       return @instance
     end
 


### PR DESCRIPTION
1. Modified the parse_instance() method inside SalesforecBulkApi Module to accommodate domain names that start with 2 alphabets and are followed by digits.

If the domain name is something like 'ab12cdef' and the salesforce instance url is 'ab12cdef.my.salesforce.com'.
The original code would evaluate the instance to ab12.salesforce.com
That would result in "Failed to open TCP connection to ab12.salesforce.com:443 (getaddrinfo: Name or service not known)" error as the host could not be resolved.

I have changed the evaluation of the @instance as follows:

@instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}\./).to_s.gsub("https://","").split(".")[0]
@instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.nil? || @instance.empty?

2. Added instructions to the README to show OAuth2 mode of authentication and the mandatory options to pass to restforce client while using client.authenticate! 