### PR TITLE
Fixed issue #59: Nils being inserted into updates that don't have them.

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -124,7 +124,7 @@ module SalesforceBulkApi
             sobject_xml += r[k].to_s
           end
           sobject_xml += "</#{k}>"
-        elsif @send_nulls && !@no_null_list.include?(k)
+        elsif @send_nulls && !@no_null_list.include?(k) && r.key?(k)
           sobject_xml += "<#{k} xsi:nil=\"true\"/>"
         end
       end


### PR DESCRIPTION
I was able to reproduce and fix this bug.  If a field was being set to `nil` for one record in an update, the `nil` was being applied to that field in all rows of the update.  Since the lack of a hash key could return `nil`, I have added a condition to the last `elsif` in the `create_sobject` method that checks if the key exists in the hash.  If it exists, then that field will be set to `nil`.  Otherwise, the field will not be set.