### PR TITLE
Bump API version to 46.0

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -13,7 +13,7 @@ module SalesforceBulkApi
   class Api
     attr_reader :connection
 
-    SALESFORCE_API_VERSION = '32.0'
+    SALESFORCE_API_VERSION = '46.0'
 
     def initialize(client)
       @connection = SalesforceBulkApi::Connection.new(SALESFORCE_API_VERSION, client)


### PR DESCRIPTION
It's been ~4.5 years since API 32.0 was released.

As stated on their [API support policy](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_support_policy.htm) a version older than 3 years might cease to be supported.
I tested:
* `SalesforceBulkApi::Api#create`
* `SalesforceBulkApi::Api#update`
* `SalesforceBulkApi::Api#delete`
* `SalesforceBulkApi::Job#check_job_status`

All of those seems to be working just fine with this bump.