### PR TITLE
Add method to fetch records from a batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ salesforce.on_job_created do |job|
 end
 ```
 
+### Fetching records from a batch
+
+```ruby
+job_id = 'l02A0231009Za8m'
+batch_id = 'H24a0708089zA2J'
+salesforce.get_batch_records(job_id, batch_id)
+# => [{"Id"=>["RECORD_ID_1"], "AField__c"=>["123123"]},
+      {"Id"=>["RECORD_ID_2"], "AField__c"=>["123123"]},
+      {"Id"=>["RECORD_ID_3"], "AField__c"=>["123123"]}]
+
+```
+
 ### Throttling API calls:
 
 ```ruby

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -224,6 +224,17 @@ module SalesforceBulkApi
       results
     end
 
+    def get_batch_records(batch_id)
+      path = "job/#{@job_id}/batch/#{batch_id}/request"
+      headers = Hash["Content-Type" => "application/xml; charset=UTF-8"]
+
+      response = @connection.get_request(nil, path, headers)
+      response_parsed = XmlSimple.xml_in(response)
+      results = response_parsed['sObject']
+
+      results
+    end
+
   end
 
   class JobTimeout < StandardError

--- a/lib/salesforce_bulk_api/version.rb
+++ b/lib/salesforce_bulk_api/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulkApi
-  VERSION = '0.0.13'
+  VERSION = '0.0.14'
 end


### PR DESCRIPTION
This is what will be returned from this method:

```ruby
[{"Id"=>["RECORD_ID_1"], "AField__c"=>["123123"]}, {"Id"=>["RECORD_ID_2"], "AField__c"=>["123123"]}, {"Id"=>["RECORD_ID_3"], "AField__c"=>["123123"]}]
```

Documentation on it: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_batches_get_request.htm

Note: It'd be nice to add some tests to it later on.