### PR TITLE
Remove documentation of syntax that no longer works

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,6 @@ salesforce.on_job_created do |job|
 end
 ```
 
-### Fetching records from a batch
-
-```ruby
-job_id = 'l02A0231009Za8m'
-batch_id = 'H24a0708089zA2J'
-salesforce.get_batch_records(job_id, batch_id)
-# => [{"Id"=>["RECORD_ID_1"], "AField__c"=>["123123"]},
-      {"Id"=>["RECORD_ID_2"], "AField__c"=>["123123"]},
-      {"Id"=>["RECORD_ID_3"], "AField__c"=>["123123"]}]
-
-```
-
 ### Throttling API calls:
 
 ```ruby


### PR DESCRIPTION
Even better would be to modify the docs to reflect the new syntax, but I
couldn't figure out how to get the new syntax to work.