### PR TITLE
Use << to concat strings instead of +=

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -22,14 +22,14 @@ module SalesforceBulkApi
       @no_null_list = no_null_list
 
       xml = "#{@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
-      xml += "<operation>#{@operation}</operation>"
-      xml += "<object>#{@sobject}</object>"
+      xml << "<operation>#{@operation}</operation>"
+      xml << "<object>#{@sobject}</object>"
       # This only happens on upsert
       if !@external_field.nil?
-        xml += "<externalIdFieldName>#{@external_field}</externalIdFieldName>"
+        xml << "<externalIdFieldName>#{@external_field}</externalIdFieldName>"
       end
-      xml += "<contentType>XML</contentType>"
-      xml += "</jobInfo>"
+      xml << "<contentType>XML</contentType>"
+      xml << "</jobInfo>"
 
       path = "job"
       headers = Hash['Content-Type' => 'application/xml; charset=utf-8']
@@ -45,8 +45,8 @@ module SalesforceBulkApi
 
     def close_job()
       xml = "#{@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
-      xml += "<state>Closed</state>"
-      xml += "</jobInfo>"
+      xml << "<state>Closed</state>"
+      xml << "</jobInfo>"
 
       path = "job/#{@job_id}"
       headers = Hash['Content-Type' => 'application/xml; charset=utf-8']
@@ -85,9 +85,9 @@ module SalesforceBulkApi
     def add_batch(keys, batch)
       xml = "#{@XML_HEADER}<sObjects xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
       batch.each do |r|
-        xml += create_sobject(keys, r)
+        xml << create_sobject(keys, r)
       end
-      xml += '</sObjects>'
+      xml << '</sObjects>'
       path = "job/#{@job_id}/batch/"
       headers = Hash["Content-Type" => "application/xml; charset=UTF-8"]
       response = @connection.post_xml(nil, path, xml, headers)
@@ -99,17 +99,17 @@ module SalesforceBulkApi
       xml = '<sObject>'
       data.keys.each do |k|
         if k.is_a?(Hash)
-          xml += build_sobject(k)
+          xml << build_sobject(k)
         elsif k.to_s.include? '.'
           relations = k.to_s.split('.')
           parent = relations[0]
           child = relations[1..-1].join('.')
-          xml += "<#{parent}>#{build_sobject({ child => data[k] })}</#{parent}>"
+          xml << "<#{parent}>#{build_sobject({ child => data[k] })}</#{parent}>"
         elsif data[k] != :type
-          xml += "<#{k}>#{data[k]}</#{k}>"
+          xml << "<#{k}>#{data[k]}</#{k}>"
         end
       end
-      xml += '</sObject>'
+      xml << '</sObject>'
     end
 
     def build_relationship_sobject(key, value)
@@ -118,10 +118,10 @@ module SalesforceBulkApi
         parent = relations[0]
         child = relations[1..-1].join('.')
         xml = "<#{parent}>"
-        xml += "<sObject>"
-        xml += build_relationship_sobject(child, value)
-        xml += "</sObject>"
-        xml += "</#{parent}>"
+        xml << "<sObject>"
+        xml << build_relationship_sobject(child, value)
+        xml << "</sObject>"
+        xml << "</#{parent}>"
       else
         xml = "<#{key}>#{value}</#{key}>"
       end
@@ -131,26 +131,26 @@ module SalesforceBulkApi
       sobject_xml = '<sObject>'
       keys.each do |k|
         if r[k].is_a?(Hash)
-          sobject_xml += "<#{k}>"
-          sobject_xml += build_sobject(r[k])
-          sobject_xml += "</#{k}>"
+          sobject_xml << "<#{k}>"
+          sobject_xml << build_sobject(r[k])
+          sobject_xml << "</#{k}>"
         elsif k.to_s.include? '.'
-          sobject_xml += build_relationship_sobject(k, r[k])
+          sobject_xml << build_relationship_sobject(k, r[k])
         elsif !r[k].to_s.empty?
-          sobject_xml += "<#{k}>"
+          sobject_xml << "<#{k}>"
           if r[k].respond_to?(:encode)
-            sobject_xml += r[k].encode(:xml => :text)
+            sobject_xml << r[k].encode(:xml => :text)
           elsif r[k].respond_to?(:iso8601) # timestamps
-            sobject_xml += r[k].iso8601.to_s
+            sobject_xml << r[k].iso8601.to_s
           else
-            sobject_xml += r[k].to_s
+            sobject_xml << r[k].to_s
           end
-          sobject_xml += "</#{k}>"
+          sobject_xml << "</#{k}>"
         elsif @send_nulls && !@no_null_list.include?(k) && r.key?(k)
-          sobject_xml += "<#{k} xsi:nil=\"true\"/>"
+          sobject_xml << "<#{k} xsi:nil=\"true\"/>"
         end
       end
-      sobject_xml += '</sObject>'
+      sobject_xml << '</sObject>'
       sobject_xml
     end
 


### PR DESCRIPTION
This greatly enhances performances when building large batches

I had a batch of 6k record that used to take up to 17seconds to build the XML, and now takes 0.2 seconds.

See this article for perfomance comparison of << over +=: https://dattdongare.com/blog/string-concatenation-ruby/