### PR TITLE
make_setting_api_version_flexible

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -13,10 +13,8 @@ module SalesforceBulkApi
   class Api
     attr_reader :connection
 
-    SALESFORCE_API_VERSION = '46.0'
-
-    def initialize(client)
-      @connection = SalesforceBulkApi::Connection.new(SALESFORCE_API_VERSION, client)
+    def initialize(client, salesforce_api_version = "46.0")
+      @connection = SalesforceBulkApi::Connection.new(salesforce_api_version, client)
       @listeners = { job_created: [] }
     end
 


### PR DESCRIPTION
### Title
Update initialize Method to Allow Setting `salesforce_api_version`

### Change Description
This pull request updates the initialize method of the class to allow setting the `salesforce_api_version`, providing more flexibility in specifying the API version for the Salesforce Bulk API. If the salesforce_api_version is not explicitly set, it will default to 46.0.

**Background:**

Previously, the class used a constant `SALESFORCE_API_VERSION` set to `46.0`, which limited the usage of this gem to API version 46.0 only. This lack of flexibility restricted the ability to use newer API features introduced in later versions.

**Example Use Case:**

One specific scenario where this limitation is problematic is when creating tasks with the owner_id set to a queue. This operation fails with API versions less than `48.0` because setting a task's owner_id to a queue is only supported in API version `48.0` and above.

By allowing the `salesforce_api_version` to be set during initialization, users can now specify the required API version to leverage newer features and avoid such issues.

**Class Initialization Update:**

**Before:**
- The class used a constant `SALESFORCE_API_VERSION` set to `'46.0'` to initialize the Salesforce connection.
- The `initialize` method accepted only one parameter, `client`.

```
SALESFORCE_API_VERSION = '46.0'

def initialize(client)
  @connection = SalesforceBulkApi::Connection.new(SALESFORCE_API_VERSION, client)
  @listeners = { job_created: [] }
end
```

**After:**
- The constant `SALESFORCE_API_VERSION` has been removed.
- The `initialize` method has been updated to accept an optional second parameter, `salesforce_api_version`, with a default value of `"46.0"`.
- This change allows for greater flexibility by enabling the specification of different Salesforce API versions during initialization.

```ruby
def initialize(client, salesforce_api_version = "46.0")
  @connection = SalesforceBulkApi::Connection.new(salesforce_api_version, client)
  @listeners = { job_created: [] }
end
```

**Summary of Changes:**
1. Removed the `SALESFORCE_API_VERSION` constant.
2. Modified the `initialize` method to accept an optional `salesforce_api_version` parameter with a default value of `"46.0"`.
3. Updated the `@connection` initialization to use the `salesforce_api_version` parameter instead of the constant.

**Benefits:**
- Increased flexibility by allowing different Salesforce API versions to be specified at runtime.
- Simplified class design by removing the constant and making the API version configurable through the initializer.